### PR TITLE
Fix null pointer exception when logging on Android

### DIFF
--- a/android/src/main/kotlin/com/greenbits/datadog_flutter/DatadogFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/greenbits/datadog_flutter/DatadogFlutterPlugin.kt
@@ -80,7 +80,7 @@ public class DatadogFlutterPlugin: FlutterPlugin, MethodCallHandler {
       call.method == "log" -> {
         val logLevel = call.argument<String>("level")!!
         val logMessage = call.argument<String>("message")!!
-        val attributes = call.argument<Map<String, Object>>("attributes")!!
+        val attributes = call.argument<Map<String, Object>>("attributes") ?: HashMap<String, Object>();
         
         when (logLevel) {
           "debug" -> {


### PR DESCRIPTION
The Android plugin expected for the `attributes` argument to
always be present when called from Dart code.

Adding a default empty attributes object fixes this issue.